### PR TITLE
FORGE-561: Fix binder array mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.onehippo.cms7</groupId>
         <artifactId>hippo-cms7-project</artifactId>
-        <version>16.3.0</version>
+        <version>16.6.5</version>
     </parent>
 
     <name>Hippo JCR POJO Binding</name>
@@ -32,12 +32,10 @@
     <url>https://github.com/bloomreach-forge/jcr-pojo-binding</url>
 
     <properties>
-
+        <!-- Versions for deps not in parent's dependencyManagement -->
         <commons-jxpath.version>1.4.0</commons-jxpath.version>
         <commons-vfs2.version>2.10.0</commons-vfs2.version>
-        <commons-collections4.version>4.5.0</commons-collections4.version>
         <jmh.version>1.37</jmh.version>
-
     </properties>
 
     <licenses>
@@ -152,37 +150,17 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>${commons-collections4.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>commons-jxpath</groupId>
             <artifactId>commons-jxpath</artifactId>
             <version>${commons-jxpath.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -200,19 +178,11 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -246,7 +216,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/onehippo/forge/content/pojo/binder/jcr/DefaultJcrContentNodeBinder.java
+++ b/src/main/java/org/onehippo/forge/content/pojo/binder/jcr/DefaultJcrContentNodeBinder.java
@@ -142,7 +142,11 @@ public class DefaultJcrContentNodeBinder implements ContentNodeBinder<Node, Cont
                                    ContentValueConverter<Value> valueConverter) throws RepositoryException {
 
         Value[] jcrValues = createJcrValues(contentProp, valueConverter);
-        if (jcrValues == null || jcrValues.length == 0) {
+        if (jcrValues.length == 0) {
+            if (contentProp.isMultiple()) {
+                int jcrType = ContentPropertyType.toJcrPropertyType(contentProp.getType());
+                jcrDataNode.setProperty(contentProp.getName(), new Value[0], jcrType);
+            }
             return;
         }
 

--- a/src/main/java/org/onehippo/forge/content/pojo/model/ContentPropertyType.java
+++ b/src/main/java/org/onehippo/forge/content/pojo/model/ContentPropertyType.java
@@ -15,6 +15,8 @@
  */
 package org.onehippo.forge.content.pojo.model;
 
+import javax.jcr.PropertyType;
+
 /**
  * Supported Content Property Types.
  */
@@ -30,4 +32,22 @@ public enum ContentPropertyType {
     PATH,
     UNDEFINED;
 
+    /**
+     * Converts this ContentPropertyType to the corresponding JCR PropertyType constant.
+     * @param type the ContentPropertyType to convert
+     * @return the JCR PropertyType constant
+     */
+    public static int toJcrPropertyType(ContentPropertyType type) {
+        return switch (type) {
+            case STRING -> PropertyType.STRING;
+            case BINARY -> PropertyType.BINARY;
+            case LONG -> PropertyType.LONG;
+            case DOUBLE -> PropertyType.DOUBLE;
+            case DATE -> PropertyType.DATE;
+            case BOOLEAN -> PropertyType.BOOLEAN;
+            case DECIMAL -> PropertyType.DECIMAL;
+            case PATH -> PropertyType.PATH;
+            default -> PropertyType.UNDEFINED;
+        };
+    }
 }

--- a/src/test/java/org/onehippo/forge/content/pojo/binder/jcr/DefaultJcrContentNodeBinderTest.java
+++ b/src/test/java/org/onehippo/forge/content/pojo/binder/jcr/DefaultJcrContentNodeBinderTest.java
@@ -23,6 +23,8 @@ import java.io.InputStream;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
 import javax.jcr.Value;
 
 import org.apache.commons.io.IOUtils;
@@ -39,6 +41,7 @@ import org.onehippo.forge.content.pojo.common.jcr.BaseHippoJcrContentNodeTest;
 import org.onehippo.forge.content.pojo.model.BinaryValue;
 import org.onehippo.forge.content.pojo.model.ContentItem;
 import org.onehippo.forge.content.pojo.model.ContentNode;
+import org.onehippo.forge.content.pojo.model.ContentProperty;
 import org.onehippo.forge.content.pojo.model.ContentPropertyType;
 import org.onehippo.repository.mock.MockNode;
 
@@ -1377,5 +1380,75 @@ public class DefaultJcrContentNodeBinderTest extends BaseHippoJcrContentNodeTest
 
         assertTrue(parentNode.hasNode("item"));
         assertFalse(parentNode.hasNode("filteredItem"));
+    }
+
+    // ==================== Empty Multi-Value Property Type Preservation Tests ====================
+
+    @Test
+    public void testBindEmptyMultiValueLongProperty_preservesType() throws Exception {
+        MockNode parentNode = getRootNode().addNode("testEmptyLong", "nt:unstructured");
+
+        ContentNode sourceNode = new ContentNode("testEmptyLong", "nt:unstructured");
+        ContentProperty longProp = new ContentProperty("ids", ContentPropertyType.LONG, true);
+        sourceNode.setProperty(longProp);
+
+        binder.bind(parentNode, sourceNode);
+
+        assertTrue(parentNode.hasProperty("ids"));
+        Property jcrProp = parentNode.getProperty("ids");
+        assertEquals(PropertyType.LONG, jcrProp.getType());
+        assertTrue(jcrProp.isMultiple());
+        assertEquals(0, jcrProp.getValues().length);
+    }
+
+    @Test
+    public void testBindEmptyMultiValueDoubleProperty_preservesType() throws Exception {
+        MockNode parentNode = getRootNode().addNode("testEmptyDouble", "nt:unstructured");
+
+        ContentNode sourceNode = new ContentNode("testEmptyDouble", "nt:unstructured");
+        ContentProperty doubleProp = new ContentProperty("scores", ContentPropertyType.DOUBLE, true);
+        sourceNode.setProperty(doubleProp);
+
+        binder.bind(parentNode, sourceNode);
+
+        assertTrue(parentNode.hasProperty("scores"));
+        Property jcrProp = parentNode.getProperty("scores");
+        assertEquals(PropertyType.DOUBLE, jcrProp.getType());
+        assertTrue(jcrProp.isMultiple());
+        assertEquals(0, jcrProp.getValues().length);
+    }
+
+    @Test
+    public void testBindEmptyMultiValueBooleanProperty_preservesType() throws Exception {
+        MockNode parentNode = getRootNode().addNode("testEmptyBoolean", "nt:unstructured");
+
+        ContentNode sourceNode = new ContentNode("testEmptyBoolean", "nt:unstructured");
+        ContentProperty boolProp = new ContentProperty("flags", ContentPropertyType.BOOLEAN, true);
+        sourceNode.setProperty(boolProp);
+
+        binder.bind(parentNode, sourceNode);
+
+        assertTrue(parentNode.hasProperty("flags"));
+        Property jcrProp = parentNode.getProperty("flags");
+        assertEquals(PropertyType.BOOLEAN, jcrProp.getType());
+        assertTrue(jcrProp.isMultiple());
+        assertEquals(0, jcrProp.getValues().length);
+    }
+
+    @Test
+    public void testBindEmptyMultiValueDateProperty_preservesType() throws Exception {
+        MockNode parentNode = getRootNode().addNode("testEmptyDate", "nt:unstructured");
+
+        ContentNode sourceNode = new ContentNode("testEmptyDate", "nt:unstructured");
+        ContentProperty dateProp = new ContentProperty("timestamps", ContentPropertyType.DATE, true);
+        sourceNode.setProperty(dateProp);
+
+        binder.bind(parentNode, sourceNode);
+
+        assertTrue(parentNode.hasProperty("timestamps"));
+        Property jcrProp = parentNode.getProperty("timestamps");
+        assertEquals(PropertyType.DATE, jcrProp.getType());
+        assertTrue(jcrProp.isMultiple());
+        assertEquals(0, jcrProp.getValues().length);
     }
 }


### PR DESCRIPTION
- fixed node binder
- improved dependency tree to alleviate upgrade headaches, anything that is transitive should grab from the parent.
- validated the fix in the dependent lib (exim plugin)